### PR TITLE
Easier Bodymovin Library loading

### DIFF
--- a/BodymovinLayer.coffee
+++ b/BodymovinLayer.coffee
@@ -5,6 +5,32 @@ Implementation of Hernan Torrisi's "Bodymovin" plugin, for Framer.
 by @72mena
 ###
 
+# INCLUDE LIBRARY ———————————————————————————
+insertScript = (localScript, webScript, name = 'JavaScript Library') ->
+	try
+		lib = Utils.domLoadDataSync localScript
+		console.log "%c#{name} Successfully Included Locally", "background: #DDFFE3; color: #007814"
+	catch e
+		try
+			lib = Utils.domLoadDataSync webScript
+			console.log "%c#{name} Successfully Included from Web", "background: #DDFFE3; color: #007814"
+		catch e
+			throw Error("Sorry, I couldn't load #{name}")
+
+
+	script = document.createElement "script"
+	script.type = "text/javascript"
+	script.innerHTML = lib
+
+	head = document.getElementsByTagName("head")[0]
+	head.appendChild script
+
+	script
+
+insertScript("modules/bodymovin.min.js", "https://raw.githubusercontent.com/bodymovin/bodymovin/master/build/player/bodymovin.min.js", "Bodymovin Library")
+
+
+# BODYMOVIN LAYER ———————————————————————————
 class exports.BodymovinLayer extends Layer
 
 	@define "speed",

--- a/README.md
+++ b/README.md
@@ -8,11 +8,8 @@ A Framer module to render JSON files exported with the Bodymovin plugin from Aft
 ## Installation
 
 1. Create a new Framer project.
-2. Download the [bodymovin plugin](https://raw.githubusercontent.com/bodymovin/bodymovin/master/build/player/bodymovin.min.js) and add it to your project and index.html
-```html
-<script src="js/bodymovin.min.js" type="text/javascript"></script>
-```
-3. Put the file `BodymovinLayer.coffee` in your modules folder.
+2. Download and put the file [`BodymovinLayer.coffee`](https://raw.githubusercontent.com/72/bodymovin-for-Framer/master/BodymovinLayer.coffee) in your modules folder.
+3. *Recommended:* Download the [`bodymovin.min.js`](https://raw.githubusercontent.com/bodymovin/bodymovin/master/build/player/bodymovin.min.js) library and put it in your modules folder.
 4. Add this line at the top of your Framer document.
 ```coffeescript
 {BodymovinLayer} = require 'BodymovinLayer'


### PR DESCRIPTION
No need for creating separate js/ folder and updating index.html.

1. Function will first look for the _bodymovin.min.js_ library locally inside modules/
2. If that fails, it turns to online loading (in case the user didn't download the library)
3. The library is then automatically added to <head> inside index.html

I created this function for my own latest module and find it really practical as you know it will always work, even if they didn't download the dependency—or they'll get a comprehensive error message in case everything fails ("Sorry, I couldn't load Bodymovin Library")