### PR TITLE
Add onLoaded event when loaded in the DOM

### DIFF
--- a/LottieLayer.coffee
+++ b/LottieLayer.coffee
@@ -125,6 +125,9 @@ class exports.LottieLayer extends Layer
 	setDirection: (direction) ->
 		direction ?= @direction
 		@_animationLayer.setDirection(direction)
+	onLoaded: (callback) ->
+		if @built
+			@_animationLayer.addEventListener "loaded", callback
 	onComplete: (callback) ->
 		if @loop
 			@_animationLayer.addEventListener "loopComplete", callback

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Examples of available events:
 customAnim.onLoaded ->
 	print 'Loaded in the DOM'
 	#Do something else
+```
 
 ```coffeescript
 customAnim.onComplete ->

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ The animation needs to be loaded in the DOM before running these 3 methods:
 Examples of available events:
 
 ```coffeescript
+customAnim.onLoaded ->
+	print 'Loaded in the DOM'
+	#Do something else
+
+```coffeescript
 customAnim.onComplete ->
 	print 'Completed.'
 	#Do something else


### PR DESCRIPTION
Makes it much easier to use the three methods that require the animation to be loaded in the DOM first.